### PR TITLE
Added option to chaneg the location of the create3 repository

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -72,7 +72,7 @@ RUN apt-get update && apt-get install -y \
 COPY fastdds /root/fastdds
 
 
-ADD create3 /root/create3
+ADD {create3_path} /root/create3
 ADD run.py /run.py
 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh

--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ python build.py --tag kipradmin/create3_docker:1.0.0
   - `--tag` (default: `kipradmin/create3_docker:latest`) - Tag the image with a custom name
   - `--platform` (default: `linux/arm64/v8`) - Build the image for a specific platform (e.g. `amd64`)
   - `--parallel` (default: `8`) - Build the create3 repo in parallel using `n` threads
+  - `--path` (default: `create3`) - Path to the create3 repo. Defaults to `create3` in the current directory

--- a/build.py
+++ b/build.py
@@ -90,7 +90,11 @@ subprocess.run([
 with open(SELF_PATH / "Dockerfile.in", "r") as f:
     dockerfile = f.read()
 
-dockerfile = dockerfile.format(parallel=args.parallel)
+create3_path_from_build_context = create3_clone_path.relative_to(SELF_PATH).as_posix()
+dockerfile = dockerfile.format(
+    parallel=args.parallel,
+    create3_path=create3_path_from_build_context
+)
 
 # Write Dockerfile
 with open(SELF_PATH / "Dockerfile", "w") as f:


### PR DESCRIPTION
Added the option for the create3 repository to be located in a different location than create3. By adding --path to the build.py argument, the repo location can be placed somewhere else (eg, external harddrive). 
The default behavior will not change with this.